### PR TITLE
Suggestions for Rust MultiPaxos

### DIFF
--- a/rust/replicant/Cargo.toml
+++ b/rust/replicant/Cargo.toml
@@ -19,3 +19,8 @@ tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 
 [build-dependencies]
 tonic-build = "0.8"
+
+[profile.release]
+codegen-units = 1
+lto = "fat"
+panic = "abort"

--- a/rust/replicant/Cargo.toml
+++ b/rust/replicant/Cargo.toml
@@ -16,6 +16,7 @@ serde_json = "1.0"
 serial_test = "*"
 tonic = "0.8"
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
+thiserror = "1.0"
 
 [build-dependencies]
 tonic-build = "0.8"

--- a/rust/replicant/src/main.rs
+++ b/rust/replicant/src/main.rs
@@ -1,3 +1,5 @@
+#![warn(clippy::pedantic)]
+
 mod replicant;
 
 use replicant::Replicant;

--- a/rust/replicant/src/replicant/kvstore/memkvstore.rs
+++ b/rust/replicant/src/replicant/kvstore/memkvstore.rs
@@ -1,4 +1,4 @@
-use super::*;
+use super::KVStore;
 use std::collections::HashMap;
 
 pub struct MemKVStore {
@@ -15,10 +15,7 @@ impl MemKVStore {
 
 impl KVStore for MemKVStore {
     fn get(&self, key: &str) -> Option<String> {
-        match self.map.get(key) {
-            Some(value) => Some(value.clone()),
-            None => None,
-        }
+        self.map.get(key).cloned()
     }
 
     fn put(&mut self, key: &str, value: &str) -> bool {
@@ -27,15 +24,16 @@ impl KVStore for MemKVStore {
     }
 
     fn del(&mut self, key: &str) -> bool {
-        match self.map.remove(key) {
-            Some(_) => true,
-            None => false,
-        }
+        self.map.remove(key).is_some()
     }
 }
 
 #[cfg(test)]
 mod tests {
+    
+
+    use crate::replicant::{multipaxos::rpc::Command, kvstore::NOT_FOUND};
+
     use super::*;
 
     const KEY1: &str = "foo";

--- a/rust/replicant/src/replicant/kvstore/memkvstore.rs
+++ b/rust/replicant/src/replicant/kvstore/memkvstore.rs
@@ -32,7 +32,7 @@ impl KVStore for MemKVStore {
 mod tests {
     
 
-    use crate::replicant::{multipaxos::rpc::Command, kvstore::NOT_FOUND};
+    use crate::replicant::{multipaxos::rpc::Command, kvstore::KVStoreError};
 
     use super::*;
 
@@ -81,9 +81,9 @@ mod tests {
         let put_key2val2 = Command::put(KEY2, VAL2);
         let put_key1val2 = Command::put(KEY1, VAL2);
 
-        assert_eq!(Err(NOT_FOUND), get_key1.execute(&mut store));
+        assert_eq!(Err(KVStoreError::NotFoundError), get_key1.execute(&mut store));
 
-        assert_eq!(Err(NOT_FOUND), del_key1.execute(&mut store));
+        assert_eq!(Err(KVStoreError::NotFoundError), del_key1.execute(&mut store));
 
         assert_eq!(Ok(None), put_key1val1.execute(&mut store));
         assert_eq!(Ok(Some(VAL1.to_string())), get_key1.execute(&mut store));
@@ -96,7 +96,7 @@ mod tests {
         assert_eq!(Ok(Some(VAL2.to_string())), get_key2.execute(&mut store));
 
         assert_eq!(Ok(None), del_key1.execute(&mut store));
-        assert_eq!(Err(NOT_FOUND), get_key1.execute(&mut store));
+        assert_eq!(Err(KVStoreError::NotFoundError), get_key1.execute(&mut store));
         assert_eq!(Ok(Some(VAL2.to_string())), get_key2.execute(&mut store));
     }
 }

--- a/rust/replicant/src/replicant/mod.rs
+++ b/rust/replicant/src/replicant/mod.rs
@@ -78,7 +78,7 @@ pub struct Shutdown {
 impl Replicant {
     pub fn new(config: &json) -> Self {
         Self {
-            replicant: Arc::new(ReplicantInner::new(&config)),
+            replicant: Arc::new(ReplicantInner::new(config)),
         }
     }
 


### PR DESCRIPTION
# Suggestions I implemented

There are 4 groups of suggestions that I have after looking at the rust implementation for a few hours. 

1. Free performance

```toml
[profile.release]
codegen-units = 1
lto = "fat"
panic = "abort"
```

This tells Cargo to compile the entire program, as well as all of it's dependencies, in one codegen unit. This makes fat LTO much better, since no cross-codegen-unit inlining/optimization opportunities are missed due to parallelism. Fat LTO allows more aggressive compiler optimizations. Setting these two options does greatly increase the compile time, which is why I only enabled it for release builds (used for performance testing).

The other option I turned on, 'panic = "abort"' changes a panic from a function call that generates a stack trace and other helpful information to a self-inflicted segfault. This is leads to smaller binary sizes and smaller functions, which helps with instruction cache. It also makes debugging very annoying if you don't use core dumps, so this can be disabled if it's the small performance boost isn't worth that. 

2. Switch from dynamic dispatch to static dispatch

By making use of generics with trait bounds, all of the dynamic dispatch calls can be made static. Making them static calls also enables LTO to perform additional optimizations on both the caller and the caller. The boundary trait I made for this is 'StaticThreadSafeKVStore', which is 'KVStore + Send + Sync + 'static'. I also added 'ThreadSafeKVStore', which can be used if you can statically prove the keys live long enough. 

I did not convert KVStore to use generics since I don't know the exact requirements of the project. If you want a generic version, try this:

```rust
pub trait KVStore<K, V> {
    fn new() -> Self;
    fn get(&self, key: K) -> Option<V>;
    fn put(&mut self, key: K, value: V) -> bool;
    fn del(&mut self, key: K) -> bool;
}
```

You will need to restrict K to K: Eq + Hash when you add them impl for MemKVStore, since the keys need to be hashable and have total equality for the standard library hash map. 

3. Applying linter suggestions

Rust has 2 linters, 'cargo check' and 'cargo clippy'. Check is the default, but clippy tries to provide suggestions to write idiomatic rust, as well as pointing out some places where you've left performance on the table or where your code is not portable. I applied all of the linter suggestions that I thought made sense, so there are still some left. I included the pedantic flag, but you may wish to disable that. If you are using rust-analyzer (the official Rust LSP implementation), you can tell it to use clippy instead of cargo check.

4. Switch error handling to thiserror for the key-value store

thiserror is a well-known error handling library for rust that allows you to easily derive Error. In this case, it allowed downsizing the error type of the key-value store from size_t to 1 byte. 

# Suggestions I did not implement

There seem to be a lot of places where Result values are not inspected, which is the same thing as doing "try { ... } catch {}" in other languages. Results should be handled via normal error handling unless you can somehow prove they will never be an error type, or you want the program to crash if that condition occurs. It is considered best practice to place a comment explaining which of these two are the reason that you are using unwrap, and include your reasoning for correctness if it is the former. 

You seem to be using ".lock().unwrap()" a lot with mutexes. If you want mutexes that can't be poisoned, and thus don't need to be unwrapped, try the ones from [parking_lot](https://docs.rs/parking_lot/latest/parking_lot/). 

You seem to rely on the "net" features in tokio, but they are only enabled due to tonic. You should probably turn them on explicitly. 

If you want to do fuzz testing, I would highly recommend [arbitrary](https://docs.rs/arbitrary/latest/arbitrary/). It allows you to produce a stream of values that match the type constraints on your data. 